### PR TITLE
Ocpb 115 frontend update chat screen to match figma

### DIFF
--- a/frontend/src/components/ChatInput/ChatInput.tsx
+++ b/frontend/src/components/ChatInput/ChatInput.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { SendHorizontal } from "lucide-react";
+
+interface ChatInputProps {
+    value: string;
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    onSend: () => void;
+    placeholder?: string;
+    disabled?: boolean;
+}
+
+export const ChatInput: React.FC<ChatInputProps> = ({
+    value,
+    onChange,
+    onSend,
+    placeholder = "Type a message...",
+    disabled = false,
+}) => {
+    const handleSubmit = (e: React.FormEvent) => {
+        e.preventDefault();
+        if (value.trim() && !disabled) {
+            onSend();
+        }
+    };
+
+    return (
+        <form onSubmit={handleSubmit} className="relative">
+            <div className="flex flex-col sm:flex-row items-center gap-3 p-2">
+                <Input
+                    value={value}
+                    onChange={onChange}
+                    className="w-full bg-slate-50 text-sm p-3 rounded-full border-none shadow-lg hover:shadow-xl focus:outline-none focus-visible:ring-0 focus:ring-0"
+                    placeholder={placeholder}
+                    disabled={disabled}
+                />
+
+                <Button
+                    type="submit"
+                    className="w-full sm:w-auto text-base py-2 px-4 rounded-full whitespace-nowrap flex items-center justify-center text-sm"
+                    disabled={disabled || !value}>
+                    Send
+                    <SendHorizontal className="w-4 h-4 ml-2" />
+                </Button>
+            </div>
+        </form>
+    );
+}; 

--- a/frontend/src/components/ChatInput/ChatInput.tsx
+++ b/frontend/src/components/ChatInput/ChatInput.tsx
@@ -1,12 +1,9 @@
 import React from "react";
 import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
-import { SendHorizontal } from "lucide-react";
 
 interface ChatInputProps {
     value: string;
     onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-    onSend: () => void;
     placeholder?: string;
     disabled?: boolean;
 }
@@ -14,36 +11,16 @@ interface ChatInputProps {
 export const ChatInput: React.FC<ChatInputProps> = ({
     value,
     onChange,
-    onSend,
     placeholder = "Type a message...",
     disabled = false,
 }) => {
-    const handleSubmit = (e: React.FormEvent) => {
-        e.preventDefault();
-        if (value.trim() && !disabled) {
-            onSend();
-        }
-    };
-
     return (
-        <form onSubmit={handleSubmit} className="relative">
-            <div className="flex flex-col sm:flex-row items-center gap-3 p-2">
-                <Input
-                    value={value}
-                    onChange={onChange}
-                    className="w-full bg-slate-50 text-sm p-3 rounded-full border-none shadow-lg hover:shadow-xl focus:outline-none focus-visible:ring-0 focus:ring-0"
-                    placeholder={placeholder}
-                    disabled={disabled}
-                />
-
-                <Button
-                    type="submit"
-                    className="w-full sm:w-auto text-base py-2 px-4 rounded-full whitespace-nowrap flex items-center justify-center text-sm"
-                    disabled={disabled || !value}>
-                    Send
-                    <SendHorizontal className="w-4 h-4 ml-2" />
-                </Button>
-            </div>
-        </form>
+        <Input
+            value={value}
+            onChange={onChange}
+            className="w-full bg-slate-50 text-sm p-3 rounded-full border-none shadow-lg hover:shadow-xl focus:outline-none focus-visible:ring-0 focus:ring-0"
+            placeholder={placeholder}
+            disabled={disabled}
+        />
     );
 }; 

--- a/frontend/src/components/ChatInput/ChatInput.tsx
+++ b/frontend/src/components/ChatInput/ChatInput.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import { Input } from "@/components/ui/input";
 
 interface ChatInputProps {
@@ -8,14 +8,15 @@ interface ChatInputProps {
     disabled?: boolean;
 }
 
-export const ChatInput: React.FC<ChatInputProps> = ({
+export const ChatInput = forwardRef<HTMLInputElement, ChatInputProps>(({
     value,
     onChange,
     placeholder = "Type a message...",
     disabled = false,
-}) => {
+}, ref) => {
     return (
         <Input
+            ref={ref}
             value={value}
             onChange={onChange}
             className="w-full bg-slate-50 text-sm p-3 rounded-full border-none shadow-lg hover:shadow-xl focus:outline-none focus-visible:ring-0 focus:ring-0"
@@ -23,4 +24,6 @@ export const ChatInput: React.FC<ChatInputProps> = ({
             disabled={disabled}
         />
     );
-}; 
+});
+
+ChatInput.displayName = 'ChatInput'; 

--- a/frontend/src/components/ChatInput/ChatInput.tsx
+++ b/frontend/src/components/ChatInput/ChatInput.tsx
@@ -19,7 +19,7 @@ export const ChatInput = forwardRef<HTMLInputElement, ChatInputProps>(({
             ref={ref}
             value={value}
             onChange={onChange}
-            className="w-full bg-slate-50 text-sm p-3 rounded-full border-none shadow-lg hover:shadow-xl focus:outline-none focus-visible:ring-0 focus:ring-0"
+            className="w-full bg-slate-50 text-[14px] p-4 rounded-full border-none shadow-lg hover:shadow-xl focus:outline-none focus-visible:ring-0 focus:ring-0 placeholder:text-xs placeholder:px-2"
             placeholder={placeholder}
             disabled={disabled}
         />

--- a/frontend/src/components/screens/Chat/ChatScreen.tsx
+++ b/frontend/src/components/screens/Chat/ChatScreen.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/dialog"
 import { ChatInput } from "@/components/ChatInput/ChatInput"
 import { v4 as uuidv4 } from 'uuid';
+import { LogOut } from "lucide-react"
 
 export interface ConversationData {
   messages: Message[];
@@ -43,11 +44,12 @@ async function getConversationData(conversationId: string) {
   }
 }
 
-async function sendUserMessage(conversationId: string, content: string) {
+async function sendUserMessage(conversationId: string, content: string, scenarioId: string) {
   try {
     const response = await axios.post<Message>('/api/chat/send-user-message', {
       conversationId,
-      content
+      content,
+      scenario_id: scenarioId
     });
     return response.data;
   } catch (error) {
@@ -121,8 +123,7 @@ const ChatScreen = () => {
       }));
       setInputMessage('');
 
-      // Send to API
-      const response = await sendUserMessage(conversationData.conversationId, inputMessage);
+      const response = await sendUserMessage(conversationData.conversationId, inputMessage, conversationData.scenarioId);
 
       if (response) {
         // Fetch the updated conversation data after bot response
@@ -160,26 +161,44 @@ const ChatScreen = () => {
 
 
   return (
-    <div className="flex flex-col h-screen max-w-2xl mx-auto p-4">
-      <div className="flex-grow overflow-auto mb-4">
-        {conversationData?.messages.map((m) => (
-          <div key={m.id} className={`mb-4 ${m.role === "user" ? "text-right" : "text-left"}`}>
-            <span
-              className={` inline-block p-2 rounded-lg ${m.role === "user" ? "bg-slate-50 text-black" : "bg-primary text-white"}`}
+    <div className="flex flex-col min-h-screen h-full p-4 md:p-6">
+      <div className="flex flex-col flex-grow max-w-4xl mx-auto w-full">
+        <div className="flex-grow overflow-auto mb-4 space-y-4">
+          {conversationData?.messages.map((m) => (
+            <div
+              key={m.id}
+              className={`mb-4 flex ${m.role === "user" ? "justify-end md:justify-end" : "justify-start"}`}
             >
-              {m.content}
-            </span>
-          </div>
-        ))}
-      </div>
+              <span
+                className={`inline-block p-4 rounded-lg text-sm max-w-[50%] ${m.role === "user" ? "bg-primary-light text-black" : "bg-primary text-white"
+                  }`}
+              >
+                {m.content}
+              </span>
+            </div>
+          ))}
+          <div ref={messagesEndRef} />
+        </div>
 
-      <ChatInput
-        value={inputMessage}
-        onChange={(e) => setInputMessage(e.target.value)}
-        onSend={() => handleSendMessage()}
-        placeholder="Type your message..."
-        disabled={isLoading}
-      />
+        <div className="flex items-center gap-3 w-full">
+          <div className="flex-1">
+            <ChatInput
+              value={inputMessage}
+              onChange={(e) => setInputMessage(e.target.value)}
+              onSend={() => handleSendMessage()}
+              placeholder="Type your message..."
+              disabled={isLoading}
+            />
+          </div>
+
+          <Button
+            onClick={handleEndChat}
+            className="bg-red-500 text-white hover:bg-red-600 flex-shrink-0 ml-2"
+          >
+            <LogOut />
+          </Button>
+        </div>
+      </div>
 
       <Dialog open={isEndChatModalOpen} onOpenChange={setIsEndChatModalOpen}>
         <DialogContent>

--- a/frontend/src/components/screens/Chat/ChatScreen.tsx
+++ b/frontend/src/components/screens/Chat/ChatScreen.tsx
@@ -11,7 +11,6 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-// import { ChatInput } from "@/components/ChatInput/ChatInput"
 import { v4 as uuidv4 } from 'uuid';
 import { LogOut, SendHorizontal } from "lucide-react"
 import { ChatInput } from "@/components/ChatInput/ChatInput"

--- a/frontend/src/components/screens/Chat/ChatScreen.tsx
+++ b/frontend/src/components/screens/Chat/ChatScreen.tsx
@@ -11,9 +11,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog"
-import { ChatInput } from "@/components/ChatInput/ChatInput"
+// import { ChatInput } from "@/components/ChatInput/ChatInput"
 import { v4 as uuidv4 } from 'uuid';
 import { LogOut, SendHorizontal } from "lucide-react"
+import { ChatInput } from "@/components/ChatInput/ChatInput"
 
 export interface ConversationData {
   messages: Message[];
@@ -66,12 +67,14 @@ const ChatScreen = () => {
   const searchParams = useSearchParams();
   const conversationId = searchParams.get("conversationId");
   const [isEndChatModalOpen, setIsEndChatModalOpen] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const router = useRouter()
 
 
   // Fetch initial chat data
   useEffect(() => {
+
     const fetchChat = async () => {
       if (!conversationId) return;
 
@@ -84,6 +87,7 @@ const ChatScreen = () => {
 
       } finally {
         setIsLoading(false);
+     
       }
     };
 
@@ -93,6 +97,10 @@ const ChatScreen = () => {
   // Auto-scroll to bottom on new messages
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    // Refocus input after messages update
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
   }, [conversationData?.messages]);
 
   // Send message handler
@@ -100,7 +108,6 @@ const ChatScreen = () => {
     if (e) {
       e.preventDefault();
     }
-
 
     if (!inputMessage || !conversationData?.conversationId || isLoading) return;
 
@@ -132,6 +139,10 @@ const ChatScreen = () => {
       }
 
       setIsLoading(false);
+      // Refocus input after sending message
+      if (inputRef.current) {
+        inputRef.current.focus();
+      }
     } catch (error) {
       console.error('Error sending message:', error);
       // Remove the failed message from the state
@@ -193,6 +204,7 @@ const ChatScreen = () => {
             className="grid grid-cols-[1fr_auto] gap-3"
           >
             <ChatInput
+              ref={inputRef}
               value={inputMessage}
               onChange={(e) => setInputMessage(e.target.value)}
               placeholder="Type your message..."

--- a/frontend/src/components/screens/Chat/ChatScreen.tsx
+++ b/frontend/src/components/screens/Chat/ChatScreen.tsx
@@ -181,7 +181,7 @@ const ChatScreen = () => {
               className={`grid ${m.role === "user" ? "justify-items-end" : "justify-items-start"}`}
             >
               <span
-                className={`p-4 rounded-lg text-sm max-w-[50%] ${m.role === "user"
+                className={`p-4 rounded-lg text-sm w-fit max-w-[600px] break-words ${m.role === "user"
                   ? "bg-primary-light text-black"
                   : "bg-primary text-white"
                   }`}

--- a/frontend/src/components/screens/Chat/ChatScreen.tsx
+++ b/frontend/src/components/screens/Chat/ChatScreen.tsx
@@ -108,7 +108,7 @@ const ChatScreen = () => {
       e.preventDefault();
     }
 
-    if (!inputMessage || !conversationData?.conversationId || isLoading) return;
+    if (!inputMessage.trim() || !conversationData?.conversationId || isLoading) return;
 
     try {
       setIsLoading(true);
@@ -213,7 +213,7 @@ const ChatScreen = () => {
             <Button
               type="submit"
               className="text-base py-2 px-4 rounded-full whitespace-nowrap flex items-center justify-center text-sm"
-              disabled={isLoading || !inputMessage}
+              disabled={isLoading || !inputMessage.trim()}
             >
               Send
               <SendHorizontal className="w-4 h-4 ml-2" />

--- a/frontend/src/components/screens/Chat/ChatScreen.tsx
+++ b/frontend/src/components/screens/Chat/ChatScreen.tsx
@@ -161,16 +161,19 @@ const ChatScreen = () => {
 
 
   return (
-    <div className="flex flex-col min-h-screen h-full p-4 md:p-6">
-      <div className="flex flex-col flex-grow max-w-4xl mx-auto w-full">
-        <div className="flex-grow overflow-auto mb-4 space-y-4">
+    <div className="grid min-h-screen grid-rows-[1fr_auto] p-4 md:p-6">
+      <div className="max-w-[1200px] mx-auto w-full mt-10 grid grid-rows-[1fr_auto] gap-4 h-full">
+        {/* Messages Container */}
+        <div className="overflow-auto space-y-4">
           {conversationData?.messages.map((m) => (
             <div
               key={m.id}
-              className={`mb-4 flex ${m.role === "user" ? "justify-end md:justify-end" : "justify-start"}`}
+              className={`grid ${m.role === "user" ? "justify-items-end" : "justify-items-start"}`}
             >
               <span
-                className={`inline-block p-4 rounded-lg text-sm max-w-[50%] ${m.role === "user" ? "bg-primary-light text-black" : "bg-primary text-white"
+                className={`p-4 rounded-lg text-sm max-w-[50%] ${m.role === "user"
+                  ? "bg-primary-light text-black"
+                  : "bg-primary text-white"
                   }`}
               >
                 {m.content}
@@ -180,24 +183,27 @@ const ChatScreen = () => {
           <div ref={messagesEndRef} />
         </div>
 
-        <div className="flex items-center gap-3 w-full">
-          <form onSubmit={(e) => {
-            e.preventDefault();
-            handleSendMessage();
-          }} className="flex-1 flex items-center gap-3">
-            <div className="flex-1">
-              <ChatInput
-                value={inputMessage}
-                onChange={(e) => setInputMessage(e.target.value)}
-                placeholder="Type your message..."
-                disabled={isLoading}
-              />
-            </div>
+        {/* Input Container */}
+        <div className="grid grid-cols-[1fr_auto] gap-3 mb-10">
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              handleSendMessage();
+            }}
+            className="grid grid-cols-[1fr_auto] gap-3"
+          >
+            <ChatInput
+              value={inputMessage}
+              onChange={(e) => setInputMessage(e.target.value)}
+              placeholder="Type your message..."
+              disabled={isLoading}
+            />
 
             <Button
               type="submit"
               className="text-base py-2 px-4 rounded-full whitespace-nowrap flex items-center justify-center text-sm"
-              disabled={isLoading || !inputMessage}>
+              disabled={isLoading || !inputMessage}
+            >
               Send
               <SendHorizontal className="w-4 h-4 ml-2" />
             </Button>
@@ -205,7 +211,7 @@ const ChatScreen = () => {
 
           <Button
             onClick={handleEndChat}
-            className="bg-red-500 text-white hover:bg-red-600 flex-shrink-0"
+            className="bg-red-500 text-white hover:bg-red-600"
           >
             <LogOut />
           </Button>

--- a/frontend/src/components/screens/Chat/ChatScreen.tsx
+++ b/frontend/src/components/screens/Chat/ChatScreen.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/dialog"
 import { ChatInput } from "@/components/ChatInput/ChatInput"
 import { v4 as uuidv4 } from 'uuid';
-import { LogOut } from "lucide-react"
+import { LogOut, SendHorizontal } from "lucide-react"
 
 export interface ConversationData {
   messages: Message[];
@@ -181,19 +181,31 @@ const ChatScreen = () => {
         </div>
 
         <div className="flex items-center gap-3 w-full">
-          <div className="flex-1">
-            <ChatInput
-              value={inputMessage}
-              onChange={(e) => setInputMessage(e.target.value)}
-              onSend={() => handleSendMessage()}
-              placeholder="Type your message..."
-              disabled={isLoading}
-            />
-          </div>
+          <form onSubmit={(e) => {
+            e.preventDefault();
+            handleSendMessage();
+          }} className="flex-1 flex items-center gap-3">
+            <div className="flex-1">
+              <ChatInput
+                value={inputMessage}
+                onChange={(e) => setInputMessage(e.target.value)}
+                placeholder="Type your message..."
+                disabled={isLoading}
+              />
+            </div>
+
+            <Button
+              type="submit"
+              className="text-base py-2 px-4 rounded-full whitespace-nowrap flex items-center justify-center text-sm"
+              disabled={isLoading || !inputMessage}>
+              Send
+              <SendHorizontal className="w-4 h-4 ml-2" />
+            </Button>
+          </form>
 
           <Button
             onClick={handleEndChat}
-            className="bg-red-500 text-white hover:bg-red-600 flex-shrink-0 ml-2"
+            className="bg-red-500 text-white hover:bg-red-600 flex-shrink-0"
           >
             <LogOut />
           </Button>

--- a/frontend/src/components/screens/InitiateChat/InitiateChat.tsx
+++ b/frontend/src/components/screens/InitiateChat/InitiateChat.tsx
@@ -16,6 +16,7 @@ import { Persona } from "@/types/persona";
 import { TrainingScenario } from "@/types/scenarios";
 import { Badge } from "@/components/ui/badge";
 import { SendHorizontal } from "lucide-react";
+import { ChatInput } from "@/components/ChatInput/ChatInput";
 
 const PROMPTS = [
   "Hi, can I interrupt you for a sec?",

--- a/frontend/src/components/screens/InitiateChat/InitiateChat.tsx
+++ b/frontend/src/components/screens/InitiateChat/InitiateChat.tsx
@@ -16,7 +16,6 @@ import { Persona } from "@/types/persona";
 import { TrainingScenario } from "@/types/scenarios";
 import { Badge } from "@/components/ui/badge";
 import { SendHorizontal } from "lucide-react";
-import { ChatInput } from "@/components/ChatInput/ChatInput";
 
 const PROMPTS = [
   "Hi, can I interrupt you for a sec?",


### PR DESCRIPTION
# Chat Input Component Refactor

## WHAT
- Created a new reusable `ChatInput` component
- Refactored chat UI to improve user experience and accessibility
- Added auto-focus functionality for better chat flow
- Extracted API calls into separate functions

## WHY
- Improve code reusability across chat interfaces
- Enhance user experience with consistent input behavior
- Cleaner component structure and styling

## HOW
- Created new `ChatInput` component with forwarded ref support
- Implemented auto-focus after sending messages
- Extracted API calls to separate functions for better maintainability
- Added proper form handling and keyboard support

## Files Changed

### Added

```
frontend/src/components/ChatInput/ChatInput.tsx

```


### Modified
frontend/src/components/screens/Chat/ChatScreen.tsx
```

### TL;DR

- Created reusable `ChatInput` component
- Added proper form handling with submit events
- Enhanced UI/UX with auto-focus (on send message the cursor stays focused in input) and better styling
- Updated button icons and layout structure