### PR TITLE
Ocpb 135 persona is generated twice on first render in the scenario setup screen

### DIFF
--- a/frontend/src/components/screens/ScenarioSetup/ScenarioSetup.tsx
+++ b/frontend/src/components/screens/ScenarioSetup/ScenarioSetup.tsx
@@ -80,6 +80,7 @@ export default function ScenarioSetup({ scenarioId }: ScenarioSetupComponentProp
 
     useEffect(() => {
         async function fetchData() {
+            setIsLoading(true);
             try {
                 const [scenarioData, personaData] = await Promise.all([
                     getSelectedScenario(scenarioId),
@@ -95,7 +96,7 @@ export default function ScenarioSetup({ scenarioId }: ScenarioSetupComponentProp
                     setPersona(personaData);
                 }
             } catch (error) {
-                console.error("Error fetching data:", error);
+                console.error("Error fetching initial data:", error);
             } finally {
                 setIsLoading(false);
             }
@@ -104,8 +105,8 @@ export default function ScenarioSetup({ scenarioId }: ScenarioSetupComponentProp
     }, [scenarioId, setScenario, setPersona]);
 
     const handleRegeneratePersona = async () => {
+        setIsRegeneratingPersona(true);
         try {
-            setIsRegeneratingPersona(true);
             const newPersona = await generatePersona();
             if (newPersona) {
                 setPersona(newPersona);


### PR DESCRIPTION
WHAT:
Fix double persona generation on initial render in Scenario Setup screen

WHY:
The loading states were not properly managed, causing the persona to be generated twice during the initial component mount

HOW:
- Moved setIsLoading(true) to the start of the fetchData function
- Reordered setIsRegeneratingPersona(true) to be called before the try block
- These changes ensure loading states are set before any async operations begin

TL;DR:
Fixed race condition in loading states that was causing duplicate persona generation on component mount