### PR TITLE
fix: ensure openai init is not on client

### DIFF
--- a/frontend/src/lib/init.ts
+++ b/frontend/src/lib/init.ts
@@ -10,10 +10,12 @@ if (!supabaseUrl || !supabaseKey) {
 
 export const supabase = createClient(supabaseUrl, supabaseKey);
 
+let openaiClient: OpenAI;
 
-
-const openaiClient = new OpenAI({
+if (typeof window === 'undefined') {
+  openaiClient = new OpenAI({
     apiKey: process.env.OPENAI_API_KEY,
   });
+}
 
 export { openaiClient };


### PR DESCRIPTION
# Initialize OpenAI Client Only on Server Side

## WHAT
- Modified the OpenAI client initialization to only occur in server-side contexts
- Added a conditional check using `typeof window === 'undefined'`
- Maintains the same functionality but with better security practices

## WHY
- Prevents OpenAI client initialization on the client/browser side
- Prevents potential runtime errors in browser environments (this was the main issue. NEXT doesn't expose non-PUBLIC keys to the browser. But there can be runtime errors)

## TL;DR
Added server-side-only initialization for OpenAI client to prevent API key exposure and improve security.
